### PR TITLE
FIX: build on macOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,12 @@ cmake_minimum_required(VERSION 3.15.0)
 project("keychain")
 set(BINARY_NAME "test-keychain")
 
+if (MSVC)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /std:c++17")
+else (MSVC)
+  set (CMAKE_CXX_STANDARD 17)
+endif (MSVC)
+
 # see comment in test-main.cpp
 add_library("catchmain" OBJECT "test-main.cpp")
 


### PR DESCRIPTION
missing C++17 requirement