### PR TITLE
Simplify error code handling on Windows

### DIFF
--- a/keychain.h
+++ b/keychain.h
@@ -102,6 +102,8 @@ enum class ErrorType {
  * to a function.
  */
 struct Error {
+    Error() : type(ErrorType::NoError) {}
+
     /*! \brief The type or reason of the error
      *
      * Note that some types of errors can only occur on certain platforms. In

--- a/keychain_win.cpp
+++ b/keychain_win.cpp
@@ -165,7 +165,7 @@ ScopedLpwstr makeTargetName(const std::string &package,
         // make really sure that we set an error code if we will return nullptr
         if (!err) {
             err.type = keychain::ErrorType::GenericError;
-            err.message = "failed to create credential target name";
+            err.message = "Failed to create credential target name.";
             err.code = -1; // generic non-zero
         }
     }

--- a/keychain_win.cpp
+++ b/keychain_win.cpp
@@ -162,7 +162,7 @@ ScopedLpwstr makeTargetName(const std::string &package,
     if (!result) {
         updateError(err);
 
-        // make really sure that we set an error code of we will return nullptr
+        // make really sure that we set an error code if we will return nullptr
         if (!err) {
             err.type = keychain::ErrorType::GenericError;
             err.message = "failed to create credential target name";

--- a/keychain_win.cpp
+++ b/keychain_win.cpp
@@ -157,8 +157,8 @@ void updateError(keychain::Error &err) {
  */
 ScopedLpwstr makeTargetName(const std::string &package,
                             const std::string &service, const std::string &user,
-                            Error &err) {
-    const auto result = utf8ToWideChar(package + "." + service + '/' + user);
+                            keychain::Error &err) {
+    auto result = utf8ToWideChar(package + "." + service + '/' + user);
     if (!result) {
         updateError(err);
 
@@ -166,7 +166,7 @@ ScopedLpwstr makeTargetName(const std::string &package,
         if (!err) {
             err.type = keychain::ErrorType::GenericError;
             err.message = "failed to create credential target name";
-            err.code = -1 // generic non-zero
+            err.code = -1; // generic non-zero
         }
     }
 

--- a/keychain_win.cpp
+++ b/keychain_win.cpp
@@ -161,6 +161,13 @@ ScopedLpwstr makeTargetName(const std::string &package,
     const auto result = utf8ToWideChar(package + "." + service + '/' + user);
     if (!result) {
         updateError(err);
+
+        // make really sure that we set an error code of we will return nullptr
+        if (!err) {
+            err.type = keychain::ErrorType::GenericError;
+            err.message = "failed to create credential target name";
+            err.code = -1 // generic non-zero
+        }
     }
 
     return result;

--- a/keychain_win.cpp
+++ b/keychain_win.cpp
@@ -156,9 +156,14 @@ void updateError(keychain::Error &err) {
  * The result is wrapped in a ScopedLpwstr.
  */
 ScopedLpwstr makeTargetName(const std::string &package,
-                            const std::string &service,
-                            const std::string &user) {
-    return utf8ToWideChar(package + "." + service + '/' + user);
+                            const std::string &service, const std::string &user,
+                            Error &err) {
+    const auto result = utf8ToWideChar(package + "." + service + '/' + user);
+    if (!result) {
+        updateError(err);
+    }
+
+    return result;
 }
 
 } // namespace
@@ -168,9 +173,8 @@ namespace keychain {
 void setPassword(const std::string &package, const std::string &service,
                  const std::string &user, const std::string &password,
                  Error &err) {
-    auto target_name = makeTargetName(package, service, user);
-    if (!target_name) {
-        updateError(err);
+    auto target_name = makeTargetName(package, service, user, err);
+    if (err) {
         return;
     }
 
@@ -205,9 +209,8 @@ std::string getPassword(const std::string &package, const std::string &service,
                         const std::string &user, Error &err) {
     std::string password;
 
-    auto target_name = makeTargetName(package, service, user);
-    if (!target_name) {
-        updateError(err);
+    auto target_name = makeTargetName(package, service, user, err);
+    if (err) {
         return password;
     }
 
@@ -227,8 +230,8 @@ std::string getPassword(const std::string &package, const std::string &service,
 
 void deletePassword(const std::string &package, const std::string &service,
                     const std::string &user, Error &err) {
-    auto target_name = makeTargetName(package, service, user);
-    if (!target_name) {
+    auto target_name = makeTargetName(package, service, user, err);
+    if (err) {
         return;
     }
 


### PR DESCRIPTION
#### Disclaimer

I didn't compile that. :( I can I run the GitHub CI workflow?

#### PR Comment

This does two things:

1. It calls `updateError` only in actual error conditions
2. It hands the user-provided `Error` down to `makeTargetName` so that the `updateError` call for the string mangling is centralized in there

Regarding (1): I think, our functions should not have the side-effect of re-setting the thread-local error code on success. As far as I understand, this thread-local error code should always contains "the last error". Hence, its not our place to reset this. Instead we overwrite this error code only if an actual error occurs.