### PR TITLE
Code coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,34 +3,61 @@ name: Build and test
 on: [push]
 
 jobs:
-  build-linux:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v1
 
-    - name: Install dependencies
-      run: sudo apt-get install dbus-x11 dbus gnome-keyring libgnome-keyring-dev libsecret-1-dev
-    - name: Run cmake
-      run: cmake . -DBUILD_TESTS=yes
-    - name: Build and run tests
-      run: export DISPLAY=:99.0 && eval $(dbus-launch --sh-syntax) &&
-           echo '$(whoami)' | gnome-keyring-daemon -r -d --unlock &&
-           make test
-
-  build-macos:
-    runs-on: macos-latest
-    steps:
-    - uses: actions/checkout@v1
-    - name: Run cmake
-      run: cmake . -DBUILD_TESTS=yes
-    - name: Build and run tests
-      run: make test
-
-  build-windows:
+  Windows-test:
     runs-on: windows-latest
+    strategy:
+      matrix:
+        config: [Debug, Release]
     steps:
-    - uses: actions/checkout@v1
-    - name: Run cmake
-      run: cmake -G "Visual Studio 16" . -DBUILD_TESTS=yes
-    - name: Build and run tests
-      run: cmake --build . --target test --config Release
+      - uses: actions/checkout@v2
+      - name: Run cmake
+        run: cmake -G "Visual Studio 16" . -DBUILD_TESTS=yes -DCODE_COVERAGE=no
+      - name: Build and run tests
+        run: cmake --build . --target test --config ${{ matrix.config }}
+
+  Unix-test-and-cover:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+        config: [Debug, Release, Coverage]
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install dependencies
+        run: |
+          if [ "$RUNNER_OS" == "Linux" ]; then
+            sudo apt-get install dbus-x11 dbus gnome-keyring libgnome-keyring-dev libsecret-1-dev gcovr
+          elif [ "$RUNNER_OS" == "macOS" ]; then
+            pip3 install gcovr
+          fi
+
+      - name: "CMake: configure coverage"
+        if: matrix.config == 'Coverage'
+        run: cmake . -DBUILD_TESTS=yes -DCODE_COVERAGE=yes -DCMAKE_BUILD_TYPE=Debug
+      - name: "CMake: configure test"
+        if: matrix.config != 'Coverage'
+        run: cmake . -DBUILD_TESTS=yes -DCODE_COVERAGE=no -DCMAKE_BUILD_TYPE=${{ matrix.config }}
+
+      - name: Build and run tests
+        run: |
+          if [ "$RUNNER_OS" == "Linux" ]; then
+            export DISPLAY=:99.0
+            eval $(dbus-launch --sh-syntax)
+            echo '$(whoami)' | gnome-keyring-daemon -r -d --unlock
+          fi
+          cmake --build . --target test
+
+      - name: Generate gcovr report
+        if: matrix.config == 'Coverage'
+        run: gcovr -r . -f "keychain.*" -x -o coverage.xml
+      - name: Upload coverage to Codecov
+        if: matrix.config == 'Coverage'
+        uses: codecov/codecov-action@v1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          file: ./coverage.xml
+          flags: unittests
+          name: codecov-umbrella
+          fail_ci_if_error: true

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ else (MSVC)
 endif (MSVC)
 
 # enable compiler warnings
-if (CMAKE_CXX_COMPILER_ID MATCHES "Clang" OR CMAKE_COMPILER_IS_GNUCC)
+if (CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
     set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror -Wall -Wextra -pedantic")
 elseif (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
     set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /W2 /WX")
@@ -50,6 +50,16 @@ add_library(${PROJECT_NAME} ${SOURCES})
 target_include_directories(${PROJECT_NAME} PRIVATE ${KEYCHAIN_INCLUDE_DIRS})
 set_target_properties(${PROJECT_NAME} PROPERTIES PUBLIC_HEADER "keychain.h")
 target_link_libraries(${PROJECT_NAME} PUBLIC ${KEYCHAIN_LIBRARIES})
+
+# Code Coverage Configuration
+option(CODE_COVERAGE "Enable coverage reporting" OFF)
+if(CODE_COVERAGE AND CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
+    set(COVERAGE_COMPILE_FLAGS "--coverage -g -O0")
+    set(CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} ${COVERAGE_COMPILE_FLAGS}")
+    if(CMAKE_CXX_COMPILER_ID MATCHES "GNU")
+        set(CMAKE_EXE_LINKER_FLAGS  "${CMAKE_EXE_LINKER_FLAGS} \"--coverage\"")
+    endif()
+endif()
 
 install(TARGETS ${PROJECT_NAME}
         LIBRARY DESTINATION       lib

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Keychain
 
 ![CI Badge](https://github.com/hrantzsch/keychain/workflows/Build%20and%20test/badge.svg)
+[![codecov](https://codecov.io/gh/hrantzsch/keychain/branch/master/graph/badge.svg)](https://codecov.io/gh/hrantzsch/keychain)
 
 Keychain is a thin cross-platform wrapper to access the operating system's credential storage in C++.
 Keychain supports getting, adding/replacing, and deleting passwords on macOS, Linux, and Windows.

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -5,6 +5,6 @@ add_library("catchmain" OBJECT "main.cpp")
 
 add_executable(${TEST_BINARY_NAME} $<TARGET_OBJECTS:catchmain> "tests.cpp")
 target_include_directories(${TEST_BINARY_NAME} PRIVATE ${PROJECT_SOURCE_DIR})
-target_link_libraries(${TEST_BINARY_NAME} ${PROJECT_NAME})
+target_link_libraries(${TEST_BINARY_NAME} PRIVATE ${PROJECT_NAME})
 
 add_custom_target(test ${TEST_BINARY_NAME})


### PR DESCRIPTION
Adds code coverage reports for Linux and macOS. Because the GitHub agents run Visual Studio Enterprise, we could also [add coverage reports for Windows](https://docs.microsoft.com/en-us/visualstudio/test/using-code-coverage-to-determine-how-much-code-is-being-tested?view=vs-2019), but I have no VS Enterprise to try it out locally.