### PR TITLE
Check for errors before releasing macOS keychain items

### DIFF
--- a/keychain_mac.cpp
+++ b/keychain_mac.cpp
@@ -221,7 +221,7 @@ void deletePassword(const std::string &package, const std::string &service,
         }
     }
 
-    if (item) {
+    if (!err && item) {
         CFRelease(item);
     }
 


### PR DESCRIPTION
macOS' SecKeychainFindGenericPassword can return a non-NULL item pointer even if the function fails (because the item is not found). In this case we must not try to CFRelease the item, or we'll segfault.