### PR TITLE
fix build under msys2/mingw64

### DIFF
--- a/src/keychain_win.cpp
+++ b/src/keychain_win.cpp
@@ -33,7 +33,7 @@
 
 #include <windows.h>
 #include <wincred.h>
-#include <intsafe.h> // for DWORD_MAX
+#define DWORD_MAX 0xffffffffUL
 // clang-format on
 
 namespace {
@@ -200,7 +200,7 @@ void setPassword(const std::string &package, const std::string &service,
         return;
     }
 
-    CREDENTIAL cred = {0};
+    CREDENTIAL cred = {};
     cred.Type = kCredType;
     cred.TargetName = target_name.get();
     cred.UserName = user_name.get();


### PR DESCRIPTION
trying to compile on mingw64 from msys2 gives these errors

```
[2/5] Building CXX object CMakeFiles/keychain.dir/src/keychain_win.cpp.obj
FAILED: CMakeFiles/keychain.dir/src/keychain_win.cpp.obj
C:\msys64\mingw64\bin\c++.exe -DKEYCHAIN_WINDOWS=1 -IC:/Users/user/source/repos/keychain/include -IC:/Users/user/source/repos/keychain/src -IC:/Users/user/source/repos/keychain/include/keychain -Wall -Wextra -pedantic -Werror -MD -MT CMakeFiles/keychain.dir/src/keychain_win.cpp.obj -MF CMakeFiles\keychain.dir\src\keychain_win.cpp.obj.d -o CMakeFiles/keychain.dir/src/keychain_win.cpp.obj -c C:/Users/user/source/repos/keychain/src/keychain_win.cpp
keychain/src/keychain_win.cpp: In function 'void keychain::setPassword(const std::string&, const std::string&, const std::string&, const std::string&, Error&)':
keychain/src/keychain_win.cpp:196:27: error: 'DWORD_MAX' was not declared in this scope; did you mean 'DWORD_PTR'?
  196 |         password.size() > DWORD_MAX) {
      |                           ^~~~~~~~~
      |                           DWORD_PTR
keychain/src/keychain_win.cpp:203:25: error: missing initializer for member '_CREDENTIALW::Type' [-Werror=missing-field-initializers]
  203 |     CREDENTIAL cred = {0};
      |                         ^
keychain/src/keychain_win.cpp:203:25: error: missing initializer for member '_CREDENTIALW::TargetName' [-Werror=missing-field-initializers]
keychain/src/keychain_win.cpp:203:25: error: missing initializer for member '_CREDENTIALW::Comment' [-Werror=missing-field-initializers]
keychain/src/keychain_win.cpp:203:25: error: missing initializer for member '_CREDENTIALW::LastWritten' [-Werror=missing-field-initializers]
keychain/src/keychain_win.cpp:203:25: error: missing initializer for member '_CREDENTIALW::CredentialBlobSize' [-Werror=missing-field-initializers]
keychain/src/keychain_win.cpp:203:25: error: missing initializer for member '_CREDENTIALW::CredentialBlob' [-Werror=missing-field-initializers]
keychain/src/keychain_win.cpp:203:25: error: missing initializer for member '_CREDENTIALW::Persist' [-Werror=missing-field-initializers]
keychain/src/keychain_win.cpp:203:25: error: missing initializer for member '_CREDENTIALW::AttributeCount' [-Werror=missing-field-initializers]
keychain/src/keychain_win.cpp:203:25: error: missing initializer for member '_CREDENTIALW::Attributes' [-Werror=missing-field-initializers]
keychain/src/keychain_win.cpp:203:25: error: missing initializer for member '_CREDENTIALW::TargetAlias' [-Werror=missing-field-initializers]
keychain/src/keychain_win.cpp:203:25: error: missing initializer for member '_CREDENTIALW::UserName' [-Werror=missing-field-initializers]
cc1plus.exe: all warnings being treated as errors
[3/5] Building CXX object test/CMakeFiles/catchmain.dir/main.cpp.obj
ninja: build stopped: subcommand failed.
```

DWORD_MAX doesnt exist in mingw's intsafe.h but since its the only thing used from intsafe i just pulled the definition out of it. alternatively cfgmgr32.h could be used instead which seems to have it in all versions

i think `CREDENTIAL cred = {0};` technically only initializes the first member `Flags` but `= {};` should zero initialize everything which gets rid of the error