### PR TITLE
Replace deprecated SecKeychain API with SecItem

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,4 @@ tags
 
 keychain.sublime-workspace
 keychain.sublime-project
+.vscode

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,12 +45,6 @@ elseif (APPLE)
         PRIVATE
             "src/keychain_mac.cpp")
 
-    # We're using the deprecated "Legacy Password Storage" API
-    # (SecKeychainFindGenericPassword and friends)
-    target_compile_options(${PROJECT_NAME}
-        PRIVATE
-            "-Wno-error=deprecated-declarations")
-
     find_library(COREFOUNDATION_LIBRARY CoreFoundation REQUIRED)
     find_library(SECURITY_LIBRARY Security REQUIRED)
 

--- a/src/keychain_mac.cpp
+++ b/src/keychain_mac.cpp
@@ -101,14 +101,17 @@ void updateError(keychain::Error &err, OSStatus status) {
     }
 }
 
-void handleCFCreateFailure(keychain::Error &err, const std::string &errorMessage) {
+void handleCFCreateFailure(keychain::Error &err,
+                           const std::string &errorMessage) {
     err.message = errorMessage;
     err.type = keychain::ErrorType::GenericError;
     err.code = -1;
 }
 
-CFStringRef createCFStringWithCString(const std::string &str, keychain::Error &err) {
-    CFStringRef result = CFStringCreateWithCString(kCFAllocatorDefault, str.c_str(), kCFStringEncodingUTF8);
+CFStringRef createCFStringWithCString(const std::string &str,
+                                      keychain::Error &err) {
+    CFStringRef result = CFStringCreateWithCString(
+        kCFAllocatorDefault, str.c_str(), kCFStringEncodingUTF8);
     if (result == NULL) {
         handleCFCreateFailure(err, "Failed to create CFString");
     }
@@ -116,7 +119,11 @@ CFStringRef createCFStringWithCString(const std::string &str, keychain::Error &e
 }
 
 CFMutableDictionaryRef createCFMutableDictionary(keychain::Error &err) {
-    CFMutableDictionaryRef result = CFDictionaryCreateMutable(kCFAllocatorDefault, 0, &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks);
+    CFMutableDictionaryRef result =
+        CFDictionaryCreateMutable(kCFAllocatorDefault,
+                                  0,
+                                  &kCFTypeDictionaryKeyCallBacks,
+                                  &kCFTypeDictionaryValueCallBacks);
     if (result == NULL) {
         handleCFCreateFailure(err, "Failed to create CFMutableDictionary");
     }
@@ -124,21 +131,28 @@ CFMutableDictionaryRef createCFMutableDictionary(keychain::Error &err) {
 }
 
 CFDataRef createCFData(const std::string &data, keychain::Error &err) {
-    CFDataRef result = CFDataCreate(kCFAllocatorDefault, reinterpret_cast<const UInt8 *>(data.c_str()), data.length());
+    CFDataRef result =
+        CFDataCreate(kCFAllocatorDefault,
+                     reinterpret_cast<const UInt8 *>(data.c_str()),
+                     data.length());
     if (result == NULL) {
         handleCFCreateFailure(err, "Failed to create CFData");
     }
     return result;
 }
 
-CFMutableDictionaryRef createQuery(const std::string &serviceName, const std::string &user, keychain::Error &err) {
+CFMutableDictionaryRef createQuery(const std::string &serviceName,
+                                   const std::string &user,
+                                   keychain::Error &err) {
     CFStringRef cfServiceName = createCFStringWithCString(serviceName, err);
     CFStringRef cfUser = createCFStringWithCString(user, err);
     CFMutableDictionaryRef query = createCFMutableDictionary(err);
 
     if (err.type != keychain::ErrorType::NoError) {
-        if (cfServiceName) CFRelease(cfServiceName);
-        if (cfUser) CFRelease(cfUser);
+        if (cfServiceName)
+            CFRelease(cfServiceName);
+        if (cfUser)
+            CFRelease(cfUser);
         return NULL;
     }
 
@@ -174,7 +188,8 @@ void setPassword(const std::string &package, const std::string &service,
 
     if (status == errSecDuplicateItem) {
         // password exists -- override
-        CFMutableDictionaryRef attributesToUpdate = createCFMutableDictionary(err);
+        CFMutableDictionaryRef attributesToUpdate =
+            createCFMutableDictionary(err);
         if (err.type != keychain::ErrorType::NoError) {
             CFRelease(cfPassword);
             CFRelease(query);
@@ -215,7 +230,9 @@ std::string getPassword(const std::string &package, const std::string &service,
         updateError(err, status);
     } else if (result != NULL) {
         CFDataRef cfPassword = (CFDataRef)result;
-        password = std::string(reinterpret_cast<const char *>(CFDataGetBytePtr(cfPassword)), CFDataGetLength(cfPassword));
+        password = std::string(
+            reinterpret_cast<const char *>(CFDataGetBytePtr(cfPassword)),
+            CFDataGetLength(cfPassword));
         CFRelease(result);
     }
 

--- a/src/keychain_mac.cpp
+++ b/src/keychain_mac.cpp
@@ -116,7 +116,7 @@ OSStatus modifyPassword(const std::string &serviceName, const std::string &user,
     CFDictionaryAddValue(query, kSecAttrAccount, cfUser);
     CFDictionaryAddValue(query, kSecAttrService, cfServiceName);
 
-    CFDataRef cfPassword = CFDataCreate(NULL, (const UInt8 *)password.c_str(), password.length());
+    CFDataRef cfPassword = CFDataCreate(NULL, reinterpret_cast<const UInt8 *>(password.c_str()), password.length());
     CFMutableDictionaryRef attributesToUpdate = CFDictionaryCreateMutable(NULL, 0, &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks);
     CFDictionaryAddValue(attributesToUpdate, kSecValueData, cfPassword);
 
@@ -149,7 +149,7 @@ void setPassword(const std::string &package, const std::string &service,
     CFDictionaryAddValue(query, kSecAttrAccount, cfUser);
     CFDictionaryAddValue(query, kSecAttrService, cfServiceName);
 
-    CFDataRef cfPassword = CFDataCreate(NULL, (const UInt8 *)password.c_str(), password.length());
+    CFDataRef cfPassword = CFDataCreate(NULL, reinterpret_cast<const UInt8 *>(password.c_str()), password.length());
     CFDictionaryAddValue(query, kSecValueData, cfPassword);
 
     OSStatus status = SecItemAdd(query, NULL);

--- a/src/keychain_mac.cpp
+++ b/src/keychain_mac.cpp
@@ -108,16 +108,16 @@ void updateError(keychain::Error &err, OSStatus status) {
  */
 OSStatus modifyPassword(const std::string &serviceName, const std::string &user,
                         const std::string &password) {
-    CFStringRef cfServiceName = CFStringCreateWithCString(NULL, serviceName.c_str(), kCFStringEncodingUTF8);
-    CFStringRef cfUser = CFStringCreateWithCString(NULL, user.c_str(), kCFStringEncodingUTF8);
+    CFStringRef cfServiceName = CFStringCreateWithCString(kCFAllocatorDefault, serviceName.c_str(), kCFStringEncodingUTF8);
+    CFStringRef cfUser = CFStringCreateWithCString(kCFAllocatorDefault, user.c_str(), kCFStringEncodingUTF8);
 
-    CFMutableDictionaryRef query = CFDictionaryCreateMutable(NULL, 0, &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks);
+    CFMutableDictionaryRef query = CFDictionaryCreateMutable(kCFAllocatorDefault, 0, &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks);
     CFDictionaryAddValue(query, kSecClass, kSecClassGenericPassword);
     CFDictionaryAddValue(query, kSecAttrAccount, cfUser);
     CFDictionaryAddValue(query, kSecAttrService, cfServiceName);
 
-    CFDataRef cfPassword = CFDataCreate(NULL, reinterpret_cast<const UInt8 *>(password.c_str()), password.length());
-    CFMutableDictionaryRef attributesToUpdate = CFDictionaryCreateMutable(NULL, 0, &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks);
+    CFDataRef cfPassword = CFDataCreate(kCFAllocatorDefault, reinterpret_cast<const UInt8 *>(password.c_str()), password.length());
+    CFMutableDictionaryRef attributesToUpdate = CFDictionaryCreateMutable(kCFAllocatorDefault, 0, &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks);
     CFDictionaryAddValue(attributesToUpdate, kSecValueData, cfPassword);
 
     OSStatus status = SecItemUpdate(query, attributesToUpdate);
@@ -141,15 +141,15 @@ void setPassword(const std::string &package, const std::string &service,
     err = Error{};
     const auto serviceName = makeServiceName(package, service);
 
-    CFStringRef cfServiceName = CFStringCreateWithCString(NULL, serviceName.c_str(), kCFStringEncodingUTF8);
-    CFStringRef cfUser = CFStringCreateWithCString(NULL, user.c_str(), kCFStringEncodingUTF8);
+    CFStringRef cfServiceName = CFStringCreateWithCString(kCFAllocatorDefault, serviceName.c_str(), kCFStringEncodingUTF8);
+    CFStringRef cfUser = CFStringCreateWithCString(kCFAllocatorDefault, user.c_str(), kCFStringEncodingUTF8);
 
-    CFMutableDictionaryRef query = CFDictionaryCreateMutable(NULL, 0, &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks);
+    CFMutableDictionaryRef query = CFDictionaryCreateMutable(kCFAllocatorDefault, 0, &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks);
     CFDictionaryAddValue(query, kSecClass, kSecClassGenericPassword);
     CFDictionaryAddValue(query, kSecAttrAccount, cfUser);
     CFDictionaryAddValue(query, kSecAttrService, cfServiceName);
 
-    CFDataRef cfPassword = CFDataCreate(NULL, reinterpret_cast<const UInt8 *>(password.c_str()), password.length());
+    CFDataRef cfPassword = CFDataCreate(kCFAllocatorDefault, reinterpret_cast<const UInt8 *>(password.c_str()), password.length());
     CFDictionaryAddValue(query, kSecValueData, cfPassword);
 
     OSStatus status = SecItemAdd(query, NULL);
@@ -174,10 +174,10 @@ std::string getPassword(const std::string &package, const std::string &service,
     err = Error{};
     const auto serviceName = makeServiceName(package, service);
 
-    CFStringRef cfServiceName = CFStringCreateWithCString(NULL, serviceName.c_str(), kCFStringEncodingUTF8);
-    CFStringRef cfUser = CFStringCreateWithCString(NULL, user.c_str(), kCFStringEncodingUTF8);
+    CFStringRef cfServiceName = CFStringCreateWithCString(kCFAllocatorDefault, serviceName.c_str(), kCFStringEncodingUTF8);
+    CFStringRef cfUser = CFStringCreateWithCString(kCFAllocatorDefault, user.c_str(), kCFStringEncodingUTF8);
 
-    CFMutableDictionaryRef query = CFDictionaryCreateMutable(NULL, 0, &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks);
+    CFMutableDictionaryRef query = CFDictionaryCreateMutable(kCFAllocatorDefault, 0, &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks);
     CFDictionaryAddValue(query, kSecClass, kSecClassGenericPassword);
     CFDictionaryAddValue(query, kSecAttrAccount, cfUser);
     CFDictionaryAddValue(query, kSecAttrService, cfServiceName);
@@ -208,10 +208,10 @@ void deletePassword(const std::string &package, const std::string &service,
     err = Error{};
     const auto serviceName = makeServiceName(package, service);
 
-    CFStringRef cfServiceName = CFStringCreateWithCString(NULL, serviceName.c_str(), kCFStringEncodingUTF8);
-    CFStringRef cfUser = CFStringCreateWithCString(NULL, user.c_str(), kCFStringEncodingUTF8);
+    CFStringRef cfServiceName = CFStringCreateWithCString(kCFAllocatorDefault, serviceName.c_str(), kCFStringEncodingUTF8);
+    CFStringRef cfUser = CFStringCreateWithCString(kCFAllocatorDefault, user.c_str(), kCFStringEncodingUTF8);
 
-    CFMutableDictionaryRef query = CFDictionaryCreateMutable(NULL, 0, &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks);
+    CFMutableDictionaryRef query = CFDictionaryCreateMutable(kCFAllocatorDefault, 0, &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks);
     CFDictionaryAddValue(query, kSecClass, kSecClassGenericPassword);
     CFDictionaryAddValue(query, kSecAttrAccount, cfUser);
     CFDictionaryAddValue(query, kSecAttrService, cfServiceName);


### PR DESCRIPTION
Consider this a bit of a draft, as I'm definitely not a C++ developer and have never developed against the Mac APIs before, so there may be consequences of this change that I'm not aware of. The tests are passing locally, so it seems to work.