### PR TITLE
CI: remove macOS 12 runner and fix Ubuntu

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,10 +51,6 @@ jobs:
             coverage: yes
           }
           - {
-            image: macos-12,
-            coverage: no
-          }
-          - {
             image: macos-13,
             coverage: no
           }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,7 @@ jobs:
       - name: Install dependencies
         run: |
           if [ ${{ runner.os }} == 'Linux' ]; then
+            sudo apt-get update
             sudo apt-get install dbus-x11 dbus gnome-keyring libsecret-1-dev gcovr
           elif [ ${{ runner.os }} == 'macOS' ]; then
             brew install gcovr


### PR DESCRIPTION
The macOS 12 runner is no longer supported. Ubuntu tests were failing because some dependencies were not found on the server and could not be installed.