### PR TITLE
explicitly initialize code to 0 in struct Error

### DIFF
--- a/include/keychain/keychain.h
+++ b/include/keychain/keychain.h
@@ -100,7 +100,7 @@ enum class ErrorType {
  * or failure.
  */
 struct Error {
-    Error() : type(ErrorType::NoError) {}
+    Error() : type(ErrorType::NoError), code(0) {}
 
     /*! \brief The type or reason of the error
      *


### PR DESCRIPTION
since `Error` provides a constructor, value initialization (`Error{}`) wont zero-initialize `code` leaving it uninitialized. this makes gcc mad because of `-Werror=maybe-uninitialized` and `-Werror=uninitialized`