### PR TITLE
Adds keychain availability checks for all platforms

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
 
       - name: Run cmake (Unix)
         if: runner.os != 'Windows'
-        run: cmake . -DBUILD_TESTS=yes -DCMAKE_BUILD_TYPE=Release
+        run: cmake . -DBUILD_TESTS=yes -DSIMULATE_FAILURES=yes -DCMAKE_BUILD_TYPE=Release
 
       - name: Run cmake (Windows)
         if: runner.os == 'Windows'
@@ -87,7 +87,7 @@ jobs:
         run: brew install gcovr
 
       - name: Run cmake
-        run: cmake . -DBUILD_TESTS=yes -DCODE_COVERAGE=yes -DCMAKE_BUILD_TYPE=Debug
+        run: cmake . -DBUILD_TESTS=yes -DCODE_COVERAGE=yes -DSIMULATE_FAILURES=yes -DCMAKE_BUILD_TYPE=Debug
 
       - name: Build and run tests (Linux)
         if: runner.os == 'Linux'

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,7 @@ cmake_minimum_required(VERSION 3.12.4)
 project(keychain)
 
 option(BUILD_TESTS "Build tests for ${PROJECT_NAME}" OFF)
+option(SIMULATE_FAILURES "Enable simulated failures in tests for ${PROJECT_NAME}" OFF)
 
 add_library(${PROJECT_NAME})
 target_include_directories(${PROJECT_NAME}
@@ -88,4 +89,9 @@ install(TARGETS ${PROJECT_NAME}
 
 if (BUILD_TESTS)
     add_subdirectory("test")
+    if (SIMULATE_FAILURES)
+        target_compile_definitions(${PROJECT_NAME}
+                PUBLIC
+                -DSIMULATE_FAILURES=1)
+    endif ()
 endif ()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,7 +91,10 @@ if (BUILD_TESTS)
     add_subdirectory("test")
     if (SIMULATE_FAILURES)
         target_compile_definitions(${PROJECT_NAME}
-                PUBLIC
+                PRIVATE
+                -DSIMULATE_FAILURES=1)
+        target_compile_definitions(${PROJECT_NAME}-test
+                PRIVATE
                 -DSIMULATE_FAILURES=1)
     endif ()
 endif ()

--- a/include/keychain/keychain.h
+++ b/include/keychain/keychain.h
@@ -84,11 +84,24 @@ void setPassword(const std::string &package, const std::string &service,
 void deletePassword(const std::string &package, const std::string &service,
                     const std::string &user, Error &err);
 
+/*! \brief Check if the keychain is available
+ *
+ * This function checks whether a secure keychain or credential store is
+ * available on the current platform. On platforms where the keychain is not
+ * actually used (e.g., Windows), this function is effectively a no-op but
+ * still returns true to indicate that keychain operations are permitted.
+ *
+ * \param err Output parameter communicating success or error details
+ * \return true if keychain operations are supported on this platform, false otherwise
+ */
+bool isAvailable(Error &err);
+
 enum class ErrorType {
     // update CATCH_REGISTER_ENUM in tests.cpp when changing this
     NoError = 0,
     GenericError,
     NotFound,
+    Unavailable,
     // OS-specific errors
     PasswordTooLong = 10, // Windows only
     AccessDenied,         // macOS only

--- a/include/keychain/keychain.h
+++ b/include/keychain/keychain.h
@@ -86,13 +86,14 @@ void deletePassword(const std::string &package, const std::string &service,
 
 /*! \brief Check if the keychain is available
  *
- * This function checks whether a secure keychain or credential store is
- * available on the current platform. On platforms where the keychain is not
- * actually used (e.g., Windows), this function is effectively a no-op but
- * still returns true to indicate that keychain operations are permitted.
+ * This function checks whether the platform's credential store is available
+ * and functional. On Linux and macOS, this probes the underlying service
+ * (SecretService or Keychain Services). On Windows, Credential Manager is
+ * a built-in OS component that is always available, so this is a no-op
+ * that always returns true.
  *
  * \param err Output parameter communicating success or error details
- * \return true if keychain operations are supported on this platform, false otherwise
+ * \return true if the credential store is available, false otherwise
  */
 bool isAvailable(Error &err);
 

--- a/src/keychain_linux.cpp
+++ b/src/keychain_linux.cpp
@@ -158,4 +158,33 @@ void deletePassword(const std::string &package, const std::string &service,
     }
 }
 
+bool isAvailable(Error &err) {
+    err = Error{};
+
+#ifdef SIMULATE_FAILURES
+    // TEST HOOK: Simulate failure to create SecretService
+    if (getenv("KEYCHAIN_TEST_SIMULATED_FAILURE")) {
+        err.type = ErrorType::Unavailable;
+        err.message = "Simulated failure: SecretService unavailable";
+        err.code = -1;
+        return false;
+    }
+#endif
+
+    GError *error = NULL;
+    SecretService *svc =
+        secret_service_get_sync((SecretServiceFlags)0, NULL, &error);
+
+    if (error != NULL || svc == NULL) {
+        err.type = ErrorType::Unavailable;
+        err.message = error ? error->message : "SecretService unavailable";
+        err.code = error ? error->code : -1;
+        if (error)
+            g_error_free(error);
+        return false;
+    }
+    g_object_unref(svc);
+    return true;
+}
+
 } // namespace keychain

--- a/src/keychain_mac.cpp
+++ b/src/keychain_mac.cpp
@@ -270,4 +270,49 @@ void deletePassword(const std::string &package, const std::string &service,
     updateError(err, SecItemDelete(query.get()));
 }
 
+bool isAvailable(Error &err) {
+    err = Error{};
+
+    auto query = createCFMutableDictionary(err);
+    if (!query) {
+        err.type = ErrorType::Unavailable;
+        err.message = "Failed to create query dictionary";
+        return false;
+    }
+
+    CFDictionaryAddValue(query.get(), kSecClass, kSecClassGenericPassword);
+
+    auto service =
+        createCFStringWithCString("keychain_availability_check_service", err);
+    auto account =
+        createCFStringWithCString("keychain_availability_check_account", err);
+    if (!service || !account) {
+        err.type = ErrorType::Unavailable;
+        err.message = "Failed to create service/account string";
+        return false;
+    }
+
+    CFDictionaryAddValue(query.get(), kSecAttrService, service.get());
+    CFDictionaryAddValue(query.get(), kSecAttrAccount, account.get());
+    CFDictionaryAddValue(query.get(), kSecReturnData, kCFBooleanFalse);
+
+#ifdef SIMULATE_FAILURES
+    // TEST HOOK: Simulate SecItemCopyMatching failure
+    if (getenv("KEYCHAIN_TEST_SIMULATED_FAILURE")) {
+        err.type = ErrorType::Unavailable;
+        err.message = "Simulated failure: SecItemCopyMatching";
+        return false;
+    }
+#endif
+
+    OSStatus status = SecItemCopyMatching(query.get(), nullptr);
+
+    if (status == errSecSuccess || status == errSecItemNotFound) {
+        return true;
+    } else {
+        err.type = ErrorType::Unavailable;
+        err.message = errorStatusToString(status);
+        return false;
+    }
+}
 } // namespace keychain

--- a/src/keychain_win.cpp
+++ b/src/keychain_win.cpp
@@ -250,4 +250,11 @@ void deletePassword(const std::string &package, const std::string &service,
     }
 }
 
+bool isAvailable(Error &err) {
+    // Credential Manager is always present on Windows;
+    // any runtime errors will surface in get/set/delete.
+    err = Error{};
+    return true;
+}
+
 } // namespace keychain

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -8,6 +8,7 @@ CATCH_REGISTER_ENUM(keychain::ErrorType,
                     keychain::ErrorType::NoError,
                     keychain::ErrorType::GenericError,
                     keychain::ErrorType::NotFound,
+                    keychain::ErrorType::Unavailable,
                     keychain::ErrorType::PasswordTooLong,
                     keychain::ErrorType::AccessDenied)
 // clang-format on
@@ -25,6 +26,7 @@ TEST_CASE("Keychain", "[keychain]") {
                    const std::string &service,
                    const std::string &user,
                    const std::string &password_in) {
+
         Error ec{};
         getPassword(package, service, user, ec);
         REQUIRE(ec.type == ErrorType::NotFound);
@@ -111,4 +113,48 @@ TEST_CASE("Keychain", "[keychain]") {
         deletePassword(package, service, user, ec);
         check_no_error(ec);
     }
+
+#ifdef KEYCHAIN_MACOS && SIMULATE_FAILURES
+    SECTION("isAvailable fails at SecItemCopyMatching") {
+        setenv("KEYCHAIN_TEST_SIMULATED_FAILURE", "1", 1);
+        Error ec{};
+        bool available = isAvailable(ec);
+        CHECK_FALSE(available);
+        CHECK(ec.type == ErrorType::Unavailable);
+        CHECK(ec.message.find("Simulated failure: SecItemCopyMatching") != std::string::npos);
+        unsetenv("KEYCHAIN_TEST_SIMULATED_FAILURE");
+    }
+#endif
+
+#ifdef KEYCHAIN_LINUX && SIMULATE_FAILURES
+    SECTION("isAvailable fails at SecretService creation") {
+        setenv("KEYCHAIN_TEST_SIMULATED_FAILURE", "1", 1);
+        Error ec{};
+        bool available = isAvailable(ec);
+        CHECK_FALSE(available);
+        CHECK(ec.type == ErrorType::Unavailable);
+        CHECK(ec.message.find("Simulated failure: SecretService unavailable") != std::string::npos);
+        unsetenv("KEYCHAIN_TEST_SIMULATED_FAILURE");
+    }
+#endif
+
+    SECTION("isAvailable returns true and no error on supported platforms") {
+        Error ec{};
+        bool available = isAvailable(ec);
+
+        REQUIRE(available);
+        check_no_error(ec);
+    }
+
+#ifdef SIMULATE_FAILURES
+    SECTION("Simulated failure path produces expected error state") {
+        Error ec{};
+        ec.type = ErrorType::Unavailable;
+        ec.message = "Simulated unavailable";
+
+        bool fakeAvailable = false;
+        CHECK_FALSE(fakeAvailable);
+        REQUIRE(ec.type == ErrorType::Unavailable);
+    }
+#endif
 }

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -26,7 +26,6 @@ TEST_CASE("Keychain", "[keychain]") {
                    const std::string &service,
                    const std::string &user,
                    const std::string &password_in) {
-
         Error ec{};
         getPassword(package, service, user, ec);
         REQUIRE(ec.type == ErrorType::NotFound);
@@ -114,26 +113,28 @@ TEST_CASE("Keychain", "[keychain]") {
         check_no_error(ec);
     }
 
-#ifdef KEYCHAIN_MACOS && SIMULATE_FAILURES
+#if defined(KEYCHAIN_MACOS) && defined(SIMULATE_FAILURES)
     SECTION("isAvailable fails at SecItemCopyMatching") {
         setenv("KEYCHAIN_TEST_SIMULATED_FAILURE", "1", 1);
         Error ec{};
         bool available = isAvailable(ec);
         CHECK_FALSE(available);
         CHECK(ec.type == ErrorType::Unavailable);
-        CHECK(ec.message.find("Simulated failure: SecItemCopyMatching") != std::string::npos);
+        CHECK(ec.message.find("Simulated failure: SecItemCopyMatching") !=
+              std::string::npos);
         unsetenv("KEYCHAIN_TEST_SIMULATED_FAILURE");
     }
 #endif
 
-#ifdef KEYCHAIN_LINUX && SIMULATE_FAILURES
+#if defined(KEYCHAIN_LINUX) && defined(SIMULATE_FAILURES)
     SECTION("isAvailable fails at SecretService creation") {
         setenv("KEYCHAIN_TEST_SIMULATED_FAILURE", "1", 1);
         Error ec{};
         bool available = isAvailable(ec);
         CHECK_FALSE(available);
         CHECK(ec.type == ErrorType::Unavailable);
-        CHECK(ec.message.find("Simulated failure: SecretService unavailable") != std::string::npos);
+        CHECK(ec.message.find("Simulated failure: SecretService unavailable") !=
+              std::string::npos);
         unsetenv("KEYCHAIN_TEST_SIMULATED_FAILURE");
     }
 #endif
@@ -145,16 +146,4 @@ TEST_CASE("Keychain", "[keychain]") {
         REQUIRE(available);
         check_no_error(ec);
     }
-
-#ifdef SIMULATE_FAILURES
-    SECTION("Simulated failure path produces expected error state") {
-        Error ec{};
-        ec.type = ErrorType::Unavailable;
-        ec.message = "Simulated unavailable";
-
-        bool fakeAvailable = false;
-        CHECK_FALSE(fakeAvailable);
-        REQUIRE(ec.type == ErrorType::Unavailable);
-    }
-#endif
 }


### PR DESCRIPTION
Introduces `isAvailable` function to verify keychain accessibility on Linux, macOS, and Windows.

On Linux, checks Secret Service status
On macOS, ensures a default keychain exists
On Windows, always returns true since CredentialManager is always present. 

Enhances platform-specific error handling for better diagnostics.